### PR TITLE
Add jupyter image folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+# Build the Jupyter notebook
+build-jupyter:
+	cd jupyter && docker build --tag opendatacube/jupyter:local .
+
+run-jupyter:
+	docker run \
+		--rm \
+		-p 8888:8888 \
+		opendatacube/jupyter:local

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,4 @@ build-jupyter:
 	cd jupyter && docker build --tag opendatacube/jupyter:local .
 
 run-jupyter:
-	docker run \
-		--rm \
-		-p 8888:8888 \
-		opendatacube/jupyter:local
+	cd jupyter && docker-compose up

--- a/jupyter/.gitignore
+++ b/jupyter/.gitignore
@@ -1,0 +1,1 @@
+notebooks

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -1,0 +1,44 @@
+FROM opendatacube/datacube-core
+
+# Get dependencies for Jupyter
+RUN apt-get update && apt-get install -y \
+    ipython ipython-notebook \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip3 install \
+    jupyter matplotlib \
+    && rm -rf $HOME/.cache/pip
+
+# Copy configuration of Jupyter from https://github.com/jupyter/docker-stacks/
+# Configure environment
+ENV NB_USER=jovyan \
+    NB_UID=1000 \
+    NB_GID=100
+ENV HOME=/home/$NB_USER
+
+ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/fix-permissions /usr/local/bin/fix-permissions
+RUN chmod +x /usr/local/bin/fix-permissions 
+# Create jovyan user with UID=1000 and in the 'users' group
+# and make sure these dirs are writable by the `users` group.
+RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
+    chmod g+w /etc/passwd /etc/group && \
+    fix-permissions $HOME
+
+
+# TODO: Ensure that these are all required and sensible for ODC purposes...
+ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/
+ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-notebook.sh /usr/local/bin/
+ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh /usr/local/bin/
+ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/jupyter_notebook_config.py /etc/jupyter/
+RUN chmod +rx /usr/local/bin/start.sh \
+    && chmod +rx /usr/local/bin/start-notebook.sh \
+    && chmod +rx /usr/local/bin/start-singleuser.sh \
+    && chmod +rx /etc/jupyter/jupyter_notebook_config.py
+RUN fix-permissions /etc/jupyter/
+
+# Set up the environment
+WORKDIR $HOME
+EXPOSE 8888
+CMD ["start-notebook.sh"]
+
+# Switch back to jovyan to avoid accidental container runs as root
+USER $NB_UID

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -8,37 +8,26 @@ RUN pip3 install \
     jupyter matplotlib \
     && rm -rf $HOME/.cache/pip
 
-# Copy configuration of Jupyter from https://github.com/jupyter/docker-stacks/
+# Copy some components of configuration of Jupyter from https://github.com/jupyter/docker-stacks/
 # Configure environment
-ENV NB_USER=jovyan \
+ENV NB_USER=jupyter \
     NB_UID=1000 \
     NB_GID=100
-ENV HOME=/home/$NB_USER
+ENV HOME=/notebooks
+RUN mkdir $HOME
 
 ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/fix-permissions /usr/local/bin/fix-permissions
 RUN chmod +x /usr/local/bin/fix-permissions 
-# Create jovyan user with UID=1000 and in the 'users' group
+# Create user with UID=1000 and in the 'users' group
 # and make sure these dirs are writable by the `users` group.
 RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
     chmod g+w /etc/passwd /etc/group && \
     fix-permissions $HOME
 
-
-# TODO: Ensure that these are all required and sensible for ODC purposes...
-ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start.sh /usr/local/bin/
-ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-notebook.sh /usr/local/bin/
-ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/start-singleuser.sh /usr/local/bin/
-ADD https://raw.githubusercontent.com/jupyter/docker-stacks/master/base-notebook/jupyter_notebook_config.py /etc/jupyter/
-RUN chmod +rx /usr/local/bin/start.sh \
-    && chmod +rx /usr/local/bin/start-notebook.sh \
-    && chmod +rx /usr/local/bin/start-singleuser.sh \
-    && chmod +rx /etc/jupyter/jupyter_notebook_config.py
-RUN fix-permissions /etc/jupyter/
-
 # Set up the environment
 WORKDIR $HOME
 EXPOSE 8888
-CMD ["start-notebook.sh"]
+CMD ["jupyter","notebook", "--ip=\"*\""]
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER $NB_UID

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -1,9 +1,9 @@
 FROM opendatacube/datacube-core
 
 # Get dependencies for Jupyter
-RUN apt-get update && apt-get install -y \
-    ipython ipython-notebook \
-    && rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && apt-get install -y \
+#     ipython ipython-notebook \
+#     && rm -rf /var/lib/apt/lists/*
 RUN pip3 install \
     jupyter matplotlib \
     && rm -rf $HOME/.cache/pip

--- a/jupyter/docker-compose.yml
+++ b/jupyter/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+  postgres:
+    image: postgres:10.3
+    environment:
+      - POSTGRES_DB=opendatacube
+      - POSTGRES_PASSWORD=opendatacubepassword
+      - POSTGRES_USER=opendatacube
+
+  opendatacube:
+    build:
+      context: .
+    environment:
+      - DB_HOSTNAME=postgres
+      - DB_USERNAME=opendatacube
+      - DB_PASSWORD=opendatacubepassword
+      - DB_DATABASE=opendatacube
+    ports:
+      - "8888:8888"
+    volumes:
+      - ./notebooks:/opt/odc/notebooks:rw
+    shm_size: 1g
+    command: jupyter notebook --ip="*" --NotebookApp.token='secretpassword'

--- a/jupyter/docker-compose.yml
+++ b/jupyter/docker-compose.yml
@@ -19,6 +19,6 @@ services:
     ports:
       - "8888:8888"
     volumes:
-      - ./notebooks:/opt/odc/notebooks:rw
+      - ./notebooks:/notebooks
     shm_size: 1g
     command: jupyter notebook --ip="*" --NotebookApp.token='secretpassword'

--- a/jupyter/readme.md
+++ b/jupyter/readme.md
@@ -1,0 +1,12 @@
+# Jupyter
+
+To run this image, use something like:
+
+```
+docker run \
+    --rm \
+    opendatacube/jupyter \
+    jupyter notebook --ip="*" --NotebookApp.token='secretpassword'
+```
+
+The image comes with the standard ODC installed, including the entrypoint that sets the config from the environment.


### PR DESCRIPTION
This is a child Docker image, based on the datacube-core base image.

When this is in the repo, we can set up an automatic build, so we've got a standard jupyter build.

A couple of questions, what should the name be? I'm thinking `opendatacube/jupyter` to keep it simple.